### PR TITLE
fix: the client retry to get resources without specifying namespace b…

### DIFF
--- a/internal/tools/helmchart/helmchart.go
+++ b/internal/tools/helmchart/helmchart.go
@@ -126,6 +126,12 @@ func CheckResource(ctx context.Context, ref controller.ObjectRef, opts CheckReso
 	un, err := opts.DynamicClient.Resource(gvr).
 		Namespace(ref.Namespace).
 		Get(ctx, ref.Name, metav1.GetOptions{})
+	if un == nil {
+		// Try to get the resource without the namespace. This is useful for cluster-scoped resources.
+		un, err = opts.DynamicClient.Resource(gvr).
+			Get(ctx, ref.Name, metav1.GetOptions{})
+	}
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
> **Describe the bug** (#9)
> If composition.krateo.io involves cluster-scoped CRD the deployed composition-dynamic-controller does not update the resource's status.conditions to Ready=true.


**Solution Implemented**
- the client retry to get resources without specifying namespace before returning error