### PR TITLE
feat: add postrender resource labels

### DIFF
--- a/internal/tools/helmchart/install.go
+++ b/internal/tools/helmchart/install.go
@@ -77,11 +77,10 @@ func Install(ctx context.Context, opts InstallOptions) (*release.Release, int64,
 
 	helmOpts := &helmclient.GenericHelmOptions{
 		PostRenderer: &labelsPostRender{
-			UID:                   uid,
-			CompositionAPIVersion: opts.Resource.GetAPIVersion(),
-			CompositionName:       opts.Resource.GetName(),
-			CompositionNamespace:  opts.Resource.GetNamespace(),
-			CompositionResource:   gvr.Resource,
+			UID:                  uid,
+			CompositionName:      opts.Resource.GetName(),
+			CompositionNamespace: opts.Resource.GetNamespace(),
+			CompositionGVR:       gvr,
 		},
 	}
 	rel, err := opts.HelmClient.InstallOrUpgradeChart(ctx, &chartSpec, helmOpts)

--- a/internal/tools/helmchart/install.go
+++ b/internal/tools/helmchart/install.go
@@ -77,7 +77,11 @@ func Install(ctx context.Context, opts InstallOptions) (*release.Release, int64,
 
 	helmOpts := &helmclient.GenericHelmOptions{
 		PostRenderer: &labelsPostRender{
-			UID: uid,
+			UID:                   uid,
+			CompositionAPIVersion: opts.Resource.GetAPIVersion(),
+			CompositionName:       opts.Resource.GetName(),
+			CompositionNamespace:  opts.Resource.GetNamespace(),
+			CompositionResource:   gvr.Resource,
 		},
 	}
 	rel, err := opts.HelmClient.InstallOrUpgradeChart(ctx, &chartSpec, helmOpts)

--- a/internal/tools/helmchart/postrenderer.go
+++ b/internal/tools/helmchart/postrenderer.go
@@ -9,7 +9,11 @@ import (
 )
 
 type labelsPostRender struct {
-	UID types.UID
+	UID                   types.UID
+	CompositionAPIVersion string
+	CompositionName       string
+	CompositionNamespace  string
+	CompositionResource   string
 }
 
 func (r *labelsPostRender) Run(renderedManifests *bytes.Buffer) (modifiedManifests *bytes.Buffer, err error) {
@@ -24,6 +28,10 @@ func (r *labelsPostRender) Run(renderedManifests *bytes.Buffer) (modifiedManifes
 		}
 		// your labels
 		labels["krateo.io/composition-id"] = string(r.UID)
+		labels["krateo.io/composition-apiVersion"] = r.CompositionAPIVersion
+		labels["krateo.io/composition-name"] = r.CompositionName
+		labels["krateo.io/composition-namespace"] = r.CompositionNamespace
+		labels["krateo.io/composition-resource"] = r.CompositionResource
 		v.SetLabels(labels)
 	}
 

--- a/internal/tools/helmchart/postrenderer.go
+++ b/internal/tools/helmchart/postrenderer.go
@@ -4,16 +4,16 @@ import (
 	"bytes"
 
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 )
 
 type labelsPostRender struct {
-	UID                   types.UID
-	CompositionAPIVersion string
-	CompositionName       string
-	CompositionNamespace  string
-	CompositionResource   string
+	UID                  types.UID
+	CompositionGVR       schema.GroupVersionResource
+	CompositionName      string
+	CompositionNamespace string
 }
 
 func (r *labelsPostRender) Run(renderedManifests *bytes.Buffer) (modifiedManifests *bytes.Buffer, err error) {
@@ -28,10 +28,11 @@ func (r *labelsPostRender) Run(renderedManifests *bytes.Buffer) (modifiedManifes
 		}
 		// your labels
 		labels["krateo.io/composition-id"] = string(r.UID)
-		labels["krateo.io/composition-apiVersion"] = r.CompositionAPIVersion
+		labels["krateo.io/composition-group"] = r.CompositionGVR.Group
+		labels["krateo.io/composition-version"] = r.CompositionGVR.Version
+		labels["krateo.io/composition-resource"] = r.CompositionGVR.Resource
 		labels["krateo.io/composition-name"] = r.CompositionName
 		labels["krateo.io/composition-namespace"] = r.CompositionNamespace
-		labels["krateo.io/composition-resource"] = r.CompositionResource
 		v.SetLabels(labels)
 	}
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,9 +2,9 @@
 
 # KO_DOCKER_REPO=kind.local ko build --base-import-paths .  --preserve-import-paths
 
-KO_DOCKER_REPO=kind.local ko build --base-import-paths .
+KO_DOCKER_REPO=kind.local KIND_CLUSTER_NAME=krateo-quickstart ko build --base-import-paths .
 
 printf '\n\nList of current docker images loaded in KinD:\n'
 
-kubectl get nodes kind-control-plane -o json \
+kubectl get nodes krateo-quickstart-control-plane -o json \
     | jq -r '.status.images[] | " - " + .names[-1]'


### PR DESCRIPTION
```yaml
krateo.io/composition-group: composition.krateo.io
krateo.io/composition-version: 1-1-3
krateo.io/composition-resource: fireworksapps
krateo.io/composition-name: demolive
krateo.io/composition-namespace: fireworksapp-system
```


separed composition-apiVersion in composition-group and composition-version to maintain k8s label validation regex `(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?`
